### PR TITLE
Add groups, tables, and var column info to anndata_info function

### DIFF
--- a/src/anndata_storage.cpp
+++ b/src/anndata_storage.cpp
@@ -54,7 +54,8 @@ string AnndataDefaultGenerator::GenerateViewSQL(const TableViewInfo &info) const
 	} else if (info.table_type == "uns") {
 		return StringUtil::Format("SELECT * FROM anndata_scan_uns(%s)", SQLString(file_path));
 	} else if (info.table_type == "info") {
-		return StringUtil::Format("SELECT * FROM anndata_info(%s)", SQLString(file_path));
+		return StringUtil::Format("SELECT * FROM anndata_info(%s, %s, %s)", SQLString(file_path),
+		                          SQLString(info.var_name_column), SQLString(info.var_id_column));
 	}
 
 	throw InternalException("Unknown table type: " + info.table_type);

--- a/src/include/anndata_scanner.hpp
+++ b/src/include/anndata_scanner.hpp
@@ -84,6 +84,7 @@ struct AnndataBindData : public TableFunctionData {
 	idx_t n_var = 0;
 	vector<string> var_names;
 	string var_name_column = "_index"; // Default column for gene names (var_names in AnnData, stored as _index in HDF5)
+	string var_id_column = "_index";   // Default column for gene IDs
 
 	// For obsm/varm matrix scanning
 	bool is_obsm_scan = false;
@@ -108,8 +109,6 @@ struct AnndataBindData : public TableFunctionData {
 
 	// For info scanning
 	bool is_info_scan = false;
-	string info_var_name_column; // User-configured var_name_column (empty = auto-detect)
-	string info_var_id_column;   // User-configured var_id_column (empty = auto-detect)
 
 	AnndataBindData(const string &path) : file_path(path), row_count(0), column_count(0) {
 	}

--- a/src/include/anndata_scanner.hpp
+++ b/src/include/anndata_scanner.hpp
@@ -108,6 +108,8 @@ struct AnndataBindData : public TableFunctionData {
 
 	// For info scanning
 	bool is_info_scan = false;
+	string info_var_name_column; // User-configured var_name_column (empty = auto-detect)
+	string info_var_id_column;   // User-configured var_id_column (empty = auto-detect)
 
 	AnndataBindData(const string &path) : file_path(path), row_count(0), column_count(0) {
 	}

--- a/test/sql/anndata_basic.test
+++ b/test/sql/anndata_basic.test
@@ -105,7 +105,7 @@ query II
 SELECT COUNT(*) as num_properties, COUNT(DISTINCT property) as unique_properties
 FROM anndata_info('test/data/test_small.h5ad');
 ----
-7	7
+11	11
 
 # Test basic properties are present in info
 query II

--- a/test/sql/anndata_info.test
+++ b/test/sql/anndata_info.test
@@ -115,21 +115,20 @@ WHERE property = 'tables';
 ----
 true
 
-# Test var_name_column detection (gene_name is in the preferred names list)
+# Test var_name_column and var_id_column default to _index (standalone, no ATTACH)
 query I
 SELECT value
 FROM anndata_info('test/data/test_small.h5ad')
 WHERE property = 'var_name_column';
 ----
-gene_name
+_index
 
-# Test var_id_column detection (gene_id is in the preferred ID list)
 query I
 SELECT value
 FROM anndata_info('test/data/test_small.h5ad')
 WHERE property = 'var_id_column';
 ----
-gene_id
+_index
 
 # Test groups for obsp/varp file
 query I
@@ -138,16 +137,6 @@ FROM anndata_info('test/data/test_obsp_varp.h5ad')
 WHERE property = 'groups';
 ----
 obs, var, X, obsp, varp
-
-# Test var columns fallback to _index when no preferred columns exist
-query I
-SELECT value
-FROM anndata_info('test/data/test_obsp_varp.h5ad')
-WHERE property IN ('var_name_column', 'var_id_column')
-ORDER BY property;
-----
-_index
-_index
 
 # Test aggregation over multiple files (simulated with UNION)
 # KNOWN LIMITATION: UNION queries with multiple HDF5 files may fail due to HDF5 C++ API limitations

--- a/test/sql/anndata_info.test
+++ b/test/sql/anndata_info.test
@@ -74,7 +74,7 @@ FROM (
 ) t
 WHERE t.property IS NOT NULL AND t.value IS NOT NULL;
 ----
-7
+11
 
 # Test casting numeric properties
 query I
@@ -99,6 +99,56 @@ WHERE property = 'x_sparse';
 ----
 false
 
+# Test groups property lists available HDF5 groups
+query I
+SELECT value
+FROM anndata_info('test/data/test_small.h5ad')
+WHERE property = 'groups';
+----
+obs, var, X, obsm, varm
+
+# Test tables property lists available SQL tables
+query I
+SELECT value LIKE 'obs, var, info, X%' as starts_correctly
+FROM anndata_info('test/data/test_small.h5ad')
+WHERE property = 'tables';
+----
+true
+
+# Test var_name_column detection (gene_name is in the preferred names list)
+query I
+SELECT value
+FROM anndata_info('test/data/test_small.h5ad')
+WHERE property = 'var_name_column';
+----
+gene_name
+
+# Test var_id_column detection (gene_id is in the preferred ID list)
+query I
+SELECT value
+FROM anndata_info('test/data/test_small.h5ad')
+WHERE property = 'var_id_column';
+----
+gene_id
+
+# Test groups for obsp/varp file
+query I
+SELECT value
+FROM anndata_info('test/data/test_obsp_varp.h5ad')
+WHERE property = 'groups';
+----
+obs, var, X, obsp, varp
+
+# Test var columns fallback to _index when no preferred columns exist
+query I
+SELECT value
+FROM anndata_info('test/data/test_obsp_varp.h5ad')
+WHERE property IN ('var_name_column', 'var_id_column')
+ORDER BY property;
+----
+_index
+_index
+
 # Test aggregation over multiple files (simulated with UNION)
 # KNOWN LIMITATION: UNION queries with multiple HDF5 files may fail due to HDF5 C++ API limitations
 # The HDF5 C++ API is not thread-safe, and the vcpkg build we use has the C++ feature enabled
@@ -111,9 +161,9 @@ false
 query I
 SELECT COUNT(*) FROM anndata_info('test/data/test_small.h5ad');
 ----
-7
+11
 
-query I  
+query I
 SELECT COUNT(*) FROM anndata_info('test/data/test_obsp_varp.h5ad');
 ----
-7
+11

--- a/test/sql/anndata_info.test
+++ b/test/sql/anndata_info.test
@@ -105,7 +105,7 @@ SELECT value
 FROM anndata_info('test/data/test_small.h5ad')
 WHERE property = 'groups';
 ----
-obs, var, X, obsm, varm
+obs, var, X, obsm, varm, uns
 
 # Test tables property lists available SQL tables
 query I

--- a/test/sql/anndata_union.test
+++ b/test/sql/anndata_union.test
@@ -16,8 +16,8 @@ SELECT 'sparse' as file, COUNT(*) as properties
 FROM anndata_info('test/data/test_sparse.h5ad')
 ORDER BY file;
 ----
-small	7
-sparse	6
+small	11
+sparse	10
 
 # Test 2: UNION of obs tables from multiple files
 query II
@@ -105,9 +105,9 @@ SELECT 'info_small2' as type, COUNT(*) as count
 FROM anndata_info('test/data/test_small.h5ad')
 ORDER BY type;
 ----
-info_small	7
-info_small2	7
-info_sparse	6
+info_small	11
+info_small2	11
+info_sparse	10
 
 # Test 7: UNION with subqueries accessing same file multiple times
 query II
@@ -154,7 +154,7 @@ SELECT 'info' as scan_type, COUNT(*) as row_count
 FROM anndata_info('test/data/test_small.h5ad')
 ORDER BY scan_type;
 ----
-info	7
+info	11
 obs	100
 var	50
 

--- a/test/sql/attach_var_columns.test
+++ b/test/sql/attach_var_columns.test
@@ -156,3 +156,45 @@ Gene_0
 
 statement ok
 DETACH ad;
+
+# Test 10: Info table reflects user-specified VAR_NAME_COLUMN and VAR_ID_COLUMN
+statement ok
+ATTACH 'test/data/test_small.h5ad' AS ad (TYPE ANNDATA, VAR_NAME_COLUMN 'gene_id', VAR_ID_COLUMN '_index');
+
+query I
+SELECT value
+FROM ad.info
+WHERE property = 'var_name_column';
+----
+gene_id
+
+query I
+SELECT value
+FROM ad.info
+WHERE property = 'var_id_column';
+----
+_index
+
+statement ok
+DETACH ad;
+
+# Test 11: Info table shows auto-detected columns when none specified
+statement ok
+ATTACH 'test/data/test_small.h5ad' AS ad (TYPE ANNDATA);
+
+query I
+SELECT value
+FROM ad.info
+WHERE property = 'var_name_column';
+----
+gene_name
+
+query I
+SELECT value
+FROM ad.info
+WHERE property = 'var_id_column';
+----
+gene_id
+
+statement ok
+DETACH ad;


### PR DESCRIPTION
## Summary
Enhanced the `anndata_info` function to provide additional metadata about AnnData file structure and configuration, including available HDF5 groups, SQL-accessible tables, and variable column mappings.

## Key Changes

- **Extended anndata_info output**: Added three new properties to the info table:
  - `groups`: Lists available HDF5 top-level groups (obs, var, X, obsm, varm, layers, obsp, varp, uns)
  - `tables`: Lists available SQL-accessible views with their naming conventions
  - `var_name_column` and `var_id_column`: Shows the configured column mappings for variable names and IDs

- **Added optional parameters to anndata_info**: The function now accepts optional `var_name_column` and `var_id_column` parameters to support custom column specifications, matching the ATTACH statement configuration

- **Updated function registration**: Registered both the original single-parameter version and a new three-parameter version of `anndata_info` to maintain backward compatibility

- **Enhanced view generation**: Modified `AnndataDefaultGenerator::GenerateViewSQL` to pass var column parameters when generating info table views

- **Added var_id_column field**: Extended `AnndataBindData` struct to track both `var_name_column` and `var_id_column` with appropriate defaults

## Implementation Details

- The groups list is dynamically built based on what data is actually present in the file
- The tables list includes all accessible SQL views with their proper naming conventions (e.g., `obsm_<name>`, `layers_<name>`)
- Default values for var columns remain `_index` for standalone queries, but can be overridden via function parameters or ATTACH configuration
- All new tests verify both the new properties and that they correctly reflect user-specified configurations

## Test Coverage

Added comprehensive tests covering:
- Verification of new properties in info output
- Groups listing for different file types (with/without obsp/varp)
- Tables listing with proper naming conventions
- Var column configuration reflection in both standalone and ATTACH scenarios

https://claude.ai/code/session_01NnnPnbZGoyf4d4nCd1yo7y