### PR TITLE
Bump target DuckDB version from v1.5.2 to v1.5.4

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.4
       ci_tools_version: main
       extension_name: anndata
       opt_in_archs: 'linux_amd64_musl'
@@ -26,7 +26,7 @@ jobs:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.4
       ci_tools_version: main
       extension_name: anndata
       format_checks: 'format;tidy'
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: anndata-v1.5.2-extension-linux_amd64
+          name: anndata-v1.5.4-extension-linux_amd64
           path: /tmp/extension
 
       - name: Setup DuckDB with extension
@@ -89,13 +89,13 @@ jobs:
           ls -la /tmp/extension/
 
           # Download DuckDB CLI to /tmp to avoid conflict with duckdb/ submodule
-          wget -q https://github.com/duckdb/duckdb/releases/download/v1.5.2/duckdb_cli-linux-amd64.zip -O /tmp/duckdb_cli.zip
+          wget -q https://github.com/duckdb/duckdb/releases/download/v1.5.4/duckdb_cli-linux-amd64.zip -O /tmp/duckdb_cli.zip
           unzip -o -q /tmp/duckdb_cli.zip -d /tmp/duckdb-cli
           chmod +x /tmp/duckdb-cli/duckdb
 
           # Setup extension directory (no gunzip needed - file is not compressed)
-          mkdir -p ~/.duckdb/extensions/v1.5.2/linux_amd64
-          cp /tmp/extension/anndata.duckdb_extension ~/.duckdb/extensions/v1.5.2/linux_amd64/
+          mkdir -p ~/.duckdb/extensions/v1.5.4/linux_amd64
+          cp /tmp/extension/anndata.duckdb_extension ~/.duckdb/extensions/v1.5.4/linux_amd64/
 
       - name: Run remote access tests
         env:
@@ -197,11 +197,11 @@ jobs:
       - name: Checkout DuckDB to version
         run: |
           cd duckdb
-          git checkout v1.5.2
+          git checkout v1.5.4
 
       - uses: actions/download-artifact@v4
         with:
-          name: anndata-v1.5.2-extension-${{matrix.duckdb_arch}}
+          name: anndata-v1.5.4-extension-${{matrix.duckdb_arch}}
           path: /tmp/extension
           
       - name: Deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bumped target DuckDB version from v1.5.2 to v1.5.4 (latest stable patch). v1.5.4 backports the upstream fix "Remove checked_array_iterator from fmt dep", which resolves the Windows build failure on the GitHub `windows-2025-vs2026` runner (MSVC 14.51 removed `stdext::checked_array_iterator`). v1.5.3 did not include this fix.
+
 ### Fixed
 - X wide table now renames duplicate variable (gene) names with `_1`, `_2`, ... suffixes, matching the `var`/raw-X tables and the attach-time warning. Previously, querying `*.X` on a file with non-unique `var_names` (e.g. `feature_name` used as both var_id and var_name) failed with `Binder Error: table "anndata_scan_x" has duplicate column name`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ Per [DuckDB's community-extensions guidance](https://duckdb.org/community_extens
 
 | Branch              | DuckDB target | community-extensions descriptor field |
 |---------------------|---------------|---------------------------------------|
-| `main`              | latest stable release (`v1.5.2`) | `ref` |
+| `main`              | latest stable release (`v1.5.4`) | `ref` |
 | `main-distribution` | `duckdb/main` (upcoming release) | `ref_next` |
 
 The community-extensions CI builds both. When DuckDB cuts a release, the upstream maintainers swap `ref_next` → `ref`; at that point our `main-distribution` becomes the new `main`.


### PR DESCRIPTION
## Summary
Updates the extension to target DuckDB v1.5.4 (latest stable patch) instead of v1.5.2. This change addresses a Windows build failure on the GitHub `windows-2025-vs2026` runner caused by MSVC 14.51 removing `stdext::checked_array_iterator` from the fmt dependency. v1.5.4 backports the upstream fix "Remove checked_array_iterator from fmt dep", while v1.5.3 did not include this fix.

## Key Changes
- Updated `duckdb_version` from `v1.5.2` to `v1.5.4` in CI workflow files (MainDistributionPipeline.yml)
- Updated artifact names and download URLs to reference v1.5.4
- Updated DuckDB submodule commit reference
- Updated documentation (CLAUDE.md) to reflect the new target version
- Added changelog entry documenting the version bump and rationale

## Files Modified
- `.github/workflows/MainDistributionPipeline.yml` — CI workflow version references
- `CHANGELOG.md` — Added entry explaining the version bump
- `CLAUDE.md` — Updated version documentation
- `duckdb` submodule — Updated to latest v1.5.4 compatible commit

https://claude.ai/code/session_01UC9g2tKvYZHPCoZMWJudfo